### PR TITLE
getopt_long returns an int, not a char.

### DIFF
--- a/main.c
+++ b/main.c
@@ -121,7 +121,7 @@ int main(int argc, char **argv) {
 
     while (1) {
         int option_index;
-        char c;
+        int c;
         static struct option long_options[] = 
         {
             {"extract", 0, NULL, 'x'},


### PR DESCRIPTION
c being a char broke the command-line parsing on arm-linux.