### PR TITLE
aes, utils: Avoid casting away const

### DIFF
--- a/aes.c
+++ b/aes.c
@@ -132,7 +132,7 @@ void aes_xts_encrypt(aes_ctx_t *ctx, void *dst, const void *src, size_t l, size_
         /* Workaround for Nintendo's custom sector...manually generate the tweak. */
         get_tweak(tweak, sector++);
         aes_setiv(ctx, tweak, 16);
-        aes_encrypt(ctx, (char *)dst + i, (char *)src + i, sector_size);
+        aes_encrypt(ctx, (char *)dst + i, (const char *)src + i, sector_size);
     }
 }
 
@@ -148,6 +148,6 @@ void aes_xts_decrypt(aes_ctx_t *ctx, void *dst, const void *src, size_t l, size_
         /* Workaround for Nintendo's custom sector...manually generate the tweak. */
         get_tweak(tweak, sector++);
         aes_setiv(ctx, tweak, 16);
-        aes_decrypt(ctx, (char *)dst + i, (char *)src + i, sector_size);
+        aes_decrypt(ctx, (char *)dst + i, (const char *)src + i, sector_size);
     }
 }

--- a/utils.c
+++ b/utils.c
@@ -28,7 +28,7 @@ void print_magic(const char *prefix, uint32_t magic) {
 
 /* Taken mostly from ctrtool. */
 void memdump(FILE *f, const char *prefix, const void *data, size_t size) {
-    uint8_t *p = (uint8_t *)data;
+    const uint8_t *p = (const uint8_t *)data;
 
     unsigned int prefix_len = strlen(prefix);
     size_t offset = 0;


### PR DESCRIPTION
Gets rid of -Wcast-qual warnings.