### PR TITLE
Fix a markdown error on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ NAX0 options:
 Key Derivation options:
   --sbk=key          Set console unique Secure Boot Key for key derivation.
   --tseckey=key      Set console unique TSEC Key for key derivation.```
+```
 
 ## Building
 


### PR DESCRIPTION
Seems like the codeblock for the `--help` of hactool wasn't closed properly and was consuming rest of the README.md including the "Building", "External Keys" and "Licensing" sections.

This PR fixes that tiny problem.