### PR TITLE
Resolve remaining -Wdiscarded-qualifiers warnings

### DIFF
--- a/hfs0.h
+++ b/hfs0.h
@@ -29,7 +29,7 @@ typedef struct {
     uint64_t size;
     hactool_ctx_t *tool_ctx;
     hfs0_header_t *header;
-    char *name;
+    const char *name;
 } hfs0_ctx_t;
 
 static inline hfs0_file_entry_t *hfs0_get_file_entry(hfs0_header_t *hdr, uint32_t i) {

--- a/nca.c
+++ b/nca.c
@@ -657,7 +657,7 @@ void nca_decrypt_key_area(nca_ctx_t *ctx) {
 }
 
 
-static char *nca_get_distribution_type(nca_ctx_t *ctx) {
+static const char *nca_get_distribution_type(nca_ctx_t *ctx) {
     switch (ctx->header.distribution) {
         case 0:
             return "Download";
@@ -668,7 +668,7 @@ static char *nca_get_distribution_type(nca_ctx_t *ctx) {
     }
 }
 
-static char *nca_get_content_type(nca_ctx_t *ctx) {
+static const char *nca_get_content_type(nca_ctx_t *ctx) {
     switch (ctx->header.content_type) {
         case 0:
             return "Program";
@@ -685,7 +685,7 @@ static char *nca_get_content_type(nca_ctx_t *ctx) {
     }
 }
 
-static char *nca_get_encryption_type(nca_ctx_t *ctx) {
+static const char *nca_get_encryption_type(nca_ctx_t *ctx) {
     if (ctx->has_rights_id) {
         return "Titlekey crypto";
     } else {
@@ -727,7 +727,7 @@ static void nca_print_key_area(nca_ctx_t *ctx) {
     }
 }
 
-static char *nca_get_section_type(nca_section_ctx_t *meta) {
+static const char *nca_get_section_type(nca_section_ctx_t *meta) {
     switch (meta->type) {
         case PFS0: {
             if (meta->pfs0_ctx.is_exefs) return "ExeFS";

--- a/npdm.c
+++ b/npdm.c
@@ -213,7 +213,7 @@ static const fs_perm_t fs_permissions_bool[MAX_FS_PERM_BOOL] = {
     {"Unknown (0x1A)", 0x8000000000004020}
 };
 
-char *npdm_get_proc_category(int process_category) {
+const char *npdm_get_proc_category(int process_category) {
     switch (process_category) {
         case 0:
             return "Regular Title";
@@ -224,7 +224,7 @@ char *npdm_get_proc_category(int process_category) {
     }
 }
 
-static char *kac_get_app_type(uint32_t app_type) {
+static const char *kac_get_app_type(uint32_t app_type) {
     switch (app_type) {
         case 0:
             return "System Module";

--- a/npdm.h
+++ b/npdm.h
@@ -137,7 +137,7 @@ void npdm_process(npdm_t *npdm, hactool_ctx_t *tool_ctx);
 void npdm_print(npdm_t *npdm, hactool_ctx_t *tool_ctx);
 void npdm_save(npdm_t *npdm, hactool_ctx_t *tool_ctx);
 
-char *npdm_get_proc_category(int process_category);
+const char *npdm_get_proc_category(int process_category);
 void kac_print(const uint32_t *descriptors, uint32_t num_descriptors);
 char *npdm_get_json(npdm_t *npdm);
 


### PR DESCRIPTION
This resolves the remaining warnings in the codebase, which are just trivial cases where the const qualifier is being discarded on string literals. This makes building a bit less noisy on some compilers (and more type-safe from an code point-of-view). I've kept the areas of the changes in separate commits to make it easier to see the changes individually, but can squash them into one commit if that's preferable.