### PR TITLE
Fixed possibility of missing null-terminator in strncpy(input_name)

### DIFF
--- a/main.c
+++ b/main.c
@@ -430,8 +430,8 @@ int main(int argc, char **argv) {
     }
 
     if (optind == argc - 1) {
-        /* Copy input file. */
-        strncpy(input_name, argv[optind], sizeof(input_name));
+        /* Copy input filename. */
+        strncpy(input_name, argv[optind], sizeof(input_name) - 1);
     } else if (tool_ctx.file_type != FILETYPE_BOOT0 && ((optind < argc) || (argc == 1))) {
         usage();
     }


### PR DESCRIPTION
if the input filename exceeded 512 bytes in length, there exists the possibility of a missing null-terminator for the input filename. this may or may not be problematic in this application, but GCC 8.2 emits a warning about it, and it's best practice to avoid the possibility altogether.
It's unlikely that anyone *would* do this, but it's best to prevent it from breaking things if someone *does* do this.