### PR TITLE
Implement support for 8.0.0 Kernel-embedded INI1

### DIFF
--- a/packages.h
+++ b/packages.h
@@ -8,6 +8,7 @@
 
 #define MAGIC_PK11 0x31314B50
 #define MAGIC_PK21 0x31324B50
+#define MAGIC_KRNLLDR_STRCT_END 0xD51C403E
 
 typedef struct {
     unsigned char build_hash[0x10];
@@ -90,6 +91,21 @@ typedef struct {
     pk21_header_t header;
     ini1_ctx_t ini1_ctx;
 } pk21_ctx_t;
+
+typedef struct {
+    uint32_t text_start_offset;
+    uint32_t text_end_offset;
+    uint32_t rodata_start_offset;
+    uint32_t rodata_end_offset;
+    uint32_t data_start_offset;
+    uint32_t data_end_offset;
+    uint32_t bss_start_offset;
+    uint32_t bss_end_offset;
+    uint32_t ini1_start_offset;
+    uint32_t dynamic_offset;
+    uint32_t init_array_start_offset;
+    uint32_t init_array_end_offset;
+} kernel_map_t;
 
 void pk21_process(pk21_ctx_t *ctx);
 void pk21_print(pk21_ctx_t *ctx);


### PR DESCRIPTION
Struct member names and "magic" search logic are from https://gist.github.com/TuxSH/8aea29531a071780ea043ab4d1f4e17d#file-kernel80-py-L169

Note that this simply searches for the instruction that appears immediately after the address map. This instruction appears only once in other kernel revs, but it does not demarcate the address map the same way elsewhere as on kernel 800. Here, the map is sandwiched tightly between a NOP and a function and the only references to it are by the code itself, not from looking up its offset anywhere I could find.

The struct I wrote also does not include the 3 64-bit ints that appear at the beginning of the actual map as I couldn't figure out what to call the first one and incidentally we don't need any of those values. For reference, they are:
1. An address exactly 0x40 bytes before the address of .dynamic start
2. The address of INI1 (this appears later in the struct)
3. The address of the end of the 'segment' for INI1 (it's 0x100-aligned and so extends past the end of INI1_offset + INI1_size)

Hopefully a better methodology will emerge from analysis of future kernel revisions, but this works for now.