### PR TITLE
Implement savefile reading, output, file listing, and verification

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ all:
 .c.o:
 	$(CC) $(INCLUDE) -c $(CFLAGS) -o $@ $<
 
-hactool: sha.o aes.o extkeys.o rsa.o npdm.o bktr.o kip.o packages.o pki.o pfs0.o hfs0.o nca0_romfs.o romfs.o utils.o nax0.o nso.o lz4.o nca.o xci.o main.o filepath.o ConvertUTF.o cJSON.o
+hactool: save.o sha.o aes.o extkeys.o rsa.o npdm.o bktr.o kip.o packages.o pki.o pfs0.o hfs0.o nca0_romfs.o romfs.o utils.o nax0.o nso.o lz4.o nca.o xci.o main.o filepath.o ConvertUTF.o cJSON.o
 	$(CC) -o $@ $^ $(LDFLAGS) -L $(LIBDIR)
 
 aes.o: aes.h types.h
@@ -51,6 +51,8 @@ romfs.o: ivfc.h types.h
 nca0_romfs.o: nca0_romfs.h ivfc.h types.h
 
 rsa.o: rsa.h sha.h types.h
+
+save.o: save.h ivfc.h aes.h sha.h filepath.h types.h
 
 sha.o: sha.h types.h
 

--- a/README.md
+++ b/README.md
@@ -84,6 +84,9 @@ INI1 options:
 NAX0 options:
   --sdseed=seed      Set console unique seed for SD card NAX0 encryption.
   --sdpath=path      Set relative path for NAX0 key derivation (ex: /registered/000000FF/cafebabecafebabecafebabecafebabe.nca).
+Save data options:
+  --outdir=dir       Specify save directory path.
+  --listfiles        List files in save file.
 Key Derivation options:
   --sbk=key          Set console unique Secure Boot Key for key derivation.
   --tseckey=key      Set console unique TSEC Key for key derivation.```

--- a/extkeys.c
+++ b/extkeys.c
@@ -251,6 +251,9 @@ void extkeys_initialize_settings(hactool_settings_t *settings, FILE *f) {
             } else if (strcmp(key, "package2_key_source") == 0) {
                 parse_hex_key(keyset->package2_key_source, value, sizeof(keyset->package2_key_source));
                 matched_key = 1;
+            } else if (strcmp(key, "per_console_key_source") == 0) {
+                parse_hex_key(keyset->per_console_key_source, value, sizeof(keyset->per_console_key_source));
+                matched_key = 1;
             } else if (strcmp(key, "sd_card_kek_source") == 0) {
                 parse_hex_key(keyset->sd_card_kek_source, value, sizeof(keyset->sd_card_kek_source));
                 matched_key = 1;

--- a/ivfc.h
+++ b/ivfc.h
@@ -37,6 +37,15 @@ typedef struct {
     uint8_t master_hash[0x20];
 } ivfc_hdr_t;
 
+typedef struct {
+    uint32_t magic;
+    uint32_t id;
+    uint32_t master_hash_size;
+    uint32_t num_levels;
+    ivfc_level_hdr_t level_headers[IVFC_MAX_LEVEL];
+    uint8_t salt_source[0x20];
+} ivfc_save_hdr_t;
+
 /* RomFS structs. */
 #define ROMFS_HEADER_SIZE 0x00000050
 

--- a/main.c
+++ b/main.c
@@ -13,6 +13,7 @@
 #include "extkeys.h"
 #include "packages.h"
 #include "nso.h"
+#include "save.h"
 
 static const char *prog_name = "hactool";
 
@@ -97,6 +98,9 @@ static void usage(void) {
         "NAX0 options:\n"
         "  --sdseed=seed      Set console unique seed for SD card NAX0 encryption.\n"
         "  --sdpath=path      Set relative path for NAX0 key derivation (ex: /registered/000000FF/cafebabecafebabecafebabecafebabe.nca).\n"
+        "Save data options:\n"
+        "  --outdir=dir       Specify save directory path.\n"
+        "  --listfiles        List files in save file."
         "Key Derivation options:\n"
         "  --sbk=key          Set console unique Secure Boot Key for key derivation.\n"
         "  --tseckey=key      Set console unique TSEC Key for key derivation.\n"
@@ -110,7 +114,7 @@ int main(int argc, char **argv) {
     nca_ctx_t nca_ctx;
     char input_name[0x200];
     filepath_t keypath;
-    
+
     prog_name = (argc < 1) ? "hactool" : argv[0];
 
     nca_init(&nca_ctx);
@@ -180,6 +184,7 @@ int main(int argc, char **argv) {
             {"saveini1json", 0, NULL, 38},
             {"uncompressed", 1, NULL, 39},
             {"disablekeywarns", 0, NULL, 40},
+            {"listfiles", 0, NULL, 41},
             {NULL, 0, NULL, 0},
         };
 
@@ -237,6 +242,8 @@ int main(int argc, char **argv) {
                     nca_ctx.tool_ctx->file_type = FILETYPE_NAX0;
                 } else if (!strcmp(optarg, "keygen") || !strcmp(optarg, "keys") || !strcmp(optarg, "boot0") || !strcmp(optarg, "boot")) {
                     nca_ctx.tool_ctx->file_type = FILETYPE_BOOT0;
+                } else if (!strcmp(optarg, "save")) {
+                    nca_ctx.tool_ctx->file_type = FILETYPE_SAVE;
                 }
                 break;
             case 0: filepath_set(&nca_ctx.tool_ctx->settings.section_paths[0], optarg); break;
@@ -389,6 +396,9 @@ int main(int argc, char **argv) {
                 break;
             case 40:
                 nca_ctx.tool_ctx->settings.skip_key_warnings = 1;
+                break;
+            case 41:
+                nca_ctx.tool_ctx->action |= ACTION_LISTFILES;
                 break;
             default:
                 usage();
@@ -673,6 +683,15 @@ int main(int argc, char **argv) {
             printf("--\n");
             printf("All derivable keys (using loaded sources):\n\n");
             pki_print_keys(&new_keyset);
+            break;
+        }
+        case FILETYPE_SAVE: {
+            save_ctx_t save_ctx;
+            memset(&save_ctx, 0, sizeof(save_ctx));
+            save_ctx.file = tool_ctx.file;
+            save_ctx.tool_ctx = &tool_ctx;
+            save_process(&save_ctx);
+            save_free_contexts(&save_ctx);
             break;
         }
         default: {

--- a/main.c
+++ b/main.c
@@ -100,7 +100,7 @@ static void usage(void) {
         "  --sdpath=path      Set relative path for NAX0 key derivation (ex: /registered/000000FF/cafebabecafebabecafebabecafebabe.nca).\n"
         "Save data options:\n"
         "  --outdir=dir       Specify save directory path.\n"
-        "  --listfiles        List files in save file."
+        "  --listfiles        List files in save file.\n"
         "Key Derivation options:\n"
         "  --sbk=key          Set console unique Secure Boot Key for key derivation.\n"
         "  --tseckey=key      Set console unique TSEC Key for key derivation.\n"

--- a/save.c
+++ b/save.c
@@ -1,0 +1,111 @@
+#include <string.h>
+#include <time.h>
+#include "save.h"
+#include "aes.h"
+
+void save_process(save_ctx_t *ctx) {
+    /* Read *just* safe amount. */
+    fseeko64(ctx->file, 0, SEEK_SET);
+    if (fread(&ctx->header, 1, sizeof(ctx->header), ctx->file) != sizeof(ctx->header)) {
+        fprintf(stderr, "Failed to read save header!\n");
+        exit(EXIT_FAILURE);
+    }
+
+    if ((ctx->tool_ctx->action & ACTION_VERIFY)) {
+        ctx->hash_validity = check_memory_hash_table(ctx->file, ctx->header.layout.hash, 0x300, 0x3D00, 0x3D00, 0);
+
+        unsigned char cmac[0x10];
+        memset(cmac, 0, 0x10);
+        aes_calculate_cmac(cmac, &ctx->header.layout, sizeof(ctx->header.layout), ctx->tool_ctx->settings.keyset.save_mac_key);
+        if (memcmp(cmac, &ctx->header.cmac, 0x10) == 0) {
+            ctx->disf_cmac_validity = VALIDITY_VALID;
+        } else {
+            ctx->disf_cmac_validity = VALIDITY_INVALID;
+        }
+    }
+
+    if (ctx->tool_ctx->action & ACTION_INFO) {
+        save_print(ctx);
+    }
+
+    if (ctx->tool_ctx->action & ACTION_EXTRACT) {
+        save_save(ctx);
+    }
+}
+
+void save_save(save_ctx_t *ctx) {
+
+}
+
+void save_print_ivfc_section(save_ctx_t *ctx) {
+    print_magic("    Magic:                          ", ctx->header.ivfc_header.magic);
+    printf("    ID:                             %08"PRIx32"\n", ctx->header.ivfc_header.id);
+    memdump(stdout, "    Salt Seed:                      ", &ctx->header.ivfc_header.salt_source, 0x20);
+    for (unsigned int i = 0; i < 4; i++) {
+        printf("    Level %"PRId32":\n", i);
+        printf("        Data Offset:                0x%016"PRIx64"\n", ctx->header.ivfc_header.level_headers[i].logical_offset);
+        printf("        Data Size:                  0x%016"PRIx64"\n", ctx->header.ivfc_header.level_headers[i].hash_data_size);
+        if (i != 0) {
+            printf("        Hash Offset:                0x%016"PRIx64"\n", ctx->header.ivfc_header.level_headers[i-1].logical_offset);
+        } else {
+            printf("        Hash Offset:                0x%016"PRIx64"\n", 0);
+        }
+        printf("        Hash Block Size:            0x%08"PRIx32"\n", 1 << ctx->header.ivfc_header.level_headers[i].block_size);
+    }
+}
+
+static const char *save_get_save_type(save_ctx_t *ctx) {
+    switch (ctx->header.extra_data.save_data_type) {
+        case 0:
+            return "SystemSaveData";
+        case 1:
+            return "SaveData";
+        case 2:
+            return "BcatDeliveryCacheStorage";
+        case 3:
+            return "DeviceSaveData";
+        case 4:
+            return "TemporaryStorage";
+        case 5:
+            return "CacheStorage";
+        default:
+            return "Unknown";
+    }
+}
+
+void save_print(save_ctx_t *ctx) {
+    printf("\nSave:\n");
+
+    if (ctx->tool_ctx->action & ACTION_VERIFY) {
+        if (ctx->disf_cmac_validity == VALIDITY_VALID) {
+            memdump(stdout, "Header CMAC (GOOD):                 ", &ctx->header.cmac, 0x10);
+        } else {
+            memdump(stdout, "Header CMAC (FAIL):                 ", &ctx->header.cmac, 0x10);
+        }
+    } else {
+        memdump(stdout, "Header CMAC:                        ", &ctx->header.cmac, 0x10);
+    }
+
+    printf("Title ID:                           %016"PRIx64"\n", ctx->header.extra_data.title_id);
+    memdump(stdout, "User ID:                            ", &ctx->header.extra_data.user_id, 0x10);
+    printf("Save ID:                            %016"PRIx64"\n", ctx->header.extra_data.save_id);
+    printf("Save Type:                          %s\n", save_get_save_type(ctx));
+    printf("Owner ID:                           %016"PRIx64"\n", ctx->header.extra_data.save_owner_id);
+    char timestamp[70];
+    if (strftime(timestamp, sizeof(timestamp), "%F %T UTC", gmtime((time_t *)&ctx->header.extra_data.timestamp)))
+        printf("Timestamp:                          %s\n", timestamp);
+    printf("Save Data Size:                     %016"PRIx64"\n", ctx->header.extra_data.data_size);
+    printf("Journal Size:                       %016"PRIx64"\n", ctx->header.extra_data.journal_size);
+
+    if (ctx->tool_ctx->action & ACTION_VERIFY) {
+        if (ctx->hash_validity == VALIDITY_VALID) {
+            memdump(stdout, "Header Hash (GOOD):                 ", &ctx->header.layout.hash, 0x20);
+        } else {
+            memdump(stdout, "Header Hash (FAIL):                 ", &ctx->header.layout.hash, 0x20);
+        }
+    } else {
+        memdump(stdout, "Header Hash:                        ", &ctx->header.layout.hash, 0x20);
+    }
+
+    save_print_ivfc_section(ctx);
+}

--- a/save.c
+++ b/save.c
@@ -3,26 +3,235 @@
 #include "save.h"
 #include "aes.h"
 
+#define REMAP_ENTRY_LENGTH 0x20
+
+remap_segment_ctx_t *save_remap_init_segments(remap_header_t *header, remap_entry_ctx_t *map_entries, uint32_t num_map_entries) {
+    remap_segment_ctx_t *segments =  malloc(sizeof(remap_segment_ctx_t) * header->map_segment_count);
+    unsigned int entry_idx = 0;
+
+    for (unsigned int i = 0; i < header->map_segment_count; i++) {
+        remap_segment_ctx_t seg;
+        seg.entries = malloc(sizeof(remap_entry_ctx_t));
+        memcpy(seg.entries, &map_entries[entry_idx], sizeof(remap_entry_ctx_t));
+        seg.offset = map_entries[entry_idx].virtual_offset;
+        map_entries[entry_idx].segment = &seg;
+        seg.entry_count = 1;
+        entry_idx++;
+
+        while (entry_idx < num_map_entries && map_entries[entry_idx - 1].virtual_offset_end == map_entries[entry_idx].virtual_offset) {
+            map_entries[entry_idx].segment = &seg;
+            map_entries[entry_idx - 1].next = &map_entries[entry_idx];
+            seg.entries = malloc(sizeof(remap_entry_ctx_t));
+            memcpy(seg.entries, &map_entries[entry_idx], sizeof(remap_entry_ctx_t));
+            seg.entry_count++;
+            entry_idx++;
+        }
+        seg.length = seg.entries[seg.entry_count - 1].virtual_offset_end - seg.entries[0].virtual_offset;
+        memcpy(&segments[i], &seg, sizeof(remap_segment_ctx_t));
+    }
+    return segments;
+}
+
+remap_entry_ctx_t *save_remap_get_map_entry(remap_storage_ctx_t *ctx, uint64_t offset) {
+    uint32_t segment_idx = (uint32_t)(offset >> (64 - ctx->header->segment_bits));
+    if (segment_idx < ctx->header->map_segment_count) {
+        for (unsigned int i = 0; i < ctx->segments[segment_idx].entry_count; i++)
+            if (ctx->segments[segment_idx].entries[i].virtual_offset_end > offset)
+                return &ctx->segments[segment_idx].entries[i];
+    }
+    fprintf(stderr, "Remap offset %"PRIx64" out of range!\n", offset);
+    exit(EXIT_FAILURE);
+}
+
+void save_remap_fread(remap_storage_ctx_t *ctx, void *buffer, uint64_t offset, size_t count) {
+    remap_entry_ctx_t *entry = save_remap_get_map_entry(ctx, offset);
+    uint64_t in_pos = offset;
+    uint32_t out_pos = 0;
+    uint32_t remaining = count;
+
+    while (remaining) {
+        uint64_t entry_pos = in_pos - entry->virtual_offset;
+        uint32_t bytes_to_read = entry->virtual_offset_end - in_pos < remaining ? (uint32_t)(entry->virtual_offset_end - in_pos) : remaining;
+
+        fseeko64(ctx->file, ctx->base_storage_offset + entry->physical_offset + entry_pos, SEEK_SET);
+        fread((uint8_t *)buffer + out_pos, 1, bytes_to_read, ctx->file);
+
+        out_pos += bytes_to_read;
+        in_pos += bytes_to_read;
+        remaining -= bytes_to_read;
+
+        if (in_pos >= entry->virtual_offset_end)
+            entry = entry->next;
+    }
+}
+
+void save_bitmap_set_bit(void *buffer, size_t bit_offset) {
+    *((uint8_t *)buffer + (bit_offset >> 3)) |= 1 << (bit_offset & 7);
+}
+
+void save_bitmap_clear_bit(void *buffer, size_t bit_offset) {
+    *((uint8_t *)buffer + (bit_offset >> 3)) &= ~(uint8_t)(1 << (bit_offset & 7));
+}
+
+uint8_t save_bitmap_check_bit(void *buffer, size_t bit_offset) {
+    return *((uint8_t *)buffer + (bit_offset >> 3)) & (1 << (bit_offset & 7));
+}
+
+void save_duplex_storage_init(duplex_storage_ctx_t *ctx, duplex_fs_layer_info_t *layer, void *bitmap, uint64_t bitmap_size) {
+    ctx->data_a = layer->data_a;
+    ctx->data_b = layer->data_b;
+    ctx->bitmap_storage = (uint8_t *)bitmap;
+    ctx->block_size = 1 << layer->info.block_size_power;
+
+    ctx->bitmap.data = ctx->bitmap_storage;
+    ctx->bitmap.bitmap = malloc(bitmap_size >> 3);
+
+    uint32_t bits_remaining = bitmap_size;
+    uint32_t bitmap_pos = 0;
+    uint32_t *buffer_pos = (uint32_t *)bitmap;
+    while (bits_remaining) {
+        uint32_t bits_to_read = bits_remaining < 32 ? bits_remaining : 32;
+        uint32_t val = *buffer_pos;
+        for (uint32_t i = 0; i < bits_to_read; i++) {
+            if (val & 0x80000000U)
+                save_bitmap_set_bit(ctx->bitmap.bitmap, bitmap_pos);
+            else
+                save_bitmap_clear_bit(ctx->bitmap.bitmap, bitmap_pos);
+            bitmap_pos++;
+            bits_remaining--;
+            val <<= 1;
+        }
+        buffer_pos++;
+    }
+}
+
+void save_duplex_storage_read(duplex_storage_ctx_t *ctx, void *buffer, uint64_t offset, size_t count) {
+    uint64_t in_pos = offset;
+    uint32_t out_pos = 0;
+    uint32_t remaining = count;
+
+    while (remaining) {
+        uint32_t block_num = (uint32_t)(in_pos / ctx->block_size);
+        uint32_t block_pos = (uint32_t)(in_pos % ctx->block_size);
+        uint32_t bytes_to_read = ctx->block_size - block_pos < remaining ? ctx->block_size - block_pos : remaining;
+
+        uint8_t *data = save_bitmap_check_bit(ctx->bitmap.bitmap, block_num) ? ctx->data_b : ctx->data_a;
+        memcpy((uint8_t *)buffer + out_pos, data + in_pos, bytes_to_read);
+
+        out_pos += bytes_to_read;
+        in_pos += bytes_to_read;
+        remaining -= bytes_to_read;
+    }
+}
+
 void save_process(save_ctx_t *ctx) {
-    /* Read *just* safe amount. */
+    // lh: SaveDataFileSystem ctor
+    /* Try to parse Header A. */
     fseeko64(ctx->file, 0, SEEK_SET);
     if (fread(&ctx->header, 1, sizeof(ctx->header), ctx->file) != sizeof(ctx->header)) {
         fprintf(stderr, "Failed to read save header!\n");
         exit(EXIT_FAILURE);
     }
 
-    if ((ctx->tool_ctx->action & ACTION_VERIFY)) {
-        ctx->hash_validity = check_memory_hash_table(ctx->file, ctx->header.layout.hash, 0x300, 0x3D00, 0x3D00, 0);
+    save_process_header(ctx);
 
-        unsigned char cmac[0x10];
-        memset(cmac, 0, 0x10);
-        aes_calculate_cmac(cmac, &ctx->header.layout, sizeof(ctx->header.layout), ctx->tool_ctx->settings.keyset.save_mac_key);
-        if (memcmp(cmac, &ctx->header.cmac, 0x10) == 0) {
-            ctx->disf_cmac_validity = VALIDITY_VALID;
-        } else {
-            ctx->disf_cmac_validity = VALIDITY_INVALID;
+    if (ctx->header_hash_validity == VALIDITY_INVALID) {
+        /* Try to parse Header B. */
+        fseeko64(ctx->file, 0x4000, SEEK_SET);
+        if (fread(&ctx->header, 1, sizeof(ctx->header), ctx->file) != sizeof(ctx->header)) {
+            fprintf(stderr, "Failed to read save header!\n");
+            exit(EXIT_FAILURE);
+        }
+
+        save_process_header(ctx);
+
+        if (ctx->header_hash_validity == VALIDITY_INVALID) {
+            fprintf(stderr, "Error: Save header is invalid!\n");
+            exit(EXIT_FAILURE);
         }
     }
+
+    unsigned char cmac[0x10];
+    memset(cmac, 0, 0x10);
+    aes_calculate_cmac(cmac, &ctx->header.layout, sizeof(ctx->header.layout), ctx->tool_ctx->settings.keyset.save_mac_key);
+    if (memcmp(cmac, &ctx->header.cmac, 0x10) == 0) {
+        ctx->header_cmac_validity = VALIDITY_VALID;
+    } else {
+        ctx->header_cmac_validity = VALIDITY_INVALID;
+        memdump(stdout, "bad hash ", cmac, 0x10);
+    }
+
+    /* Initialize remap storages. */
+    // lh: RemapStorage ctor for DataRemapStorage
+    ctx->data_remap_storage.base_storage_offset = ctx->header.layout.file_map_data_offset;
+    ctx->data_remap_storage.header = &ctx->header.main_remap_header;
+    ctx->data_remap_storage.map_entries = malloc(sizeof(remap_entry_ctx_t) * ctx->data_remap_storage.header->map_entry_count);
+    ctx->data_remap_storage.file = ctx->file;
+    fseeko64(ctx->file, ctx->header.layout.file_map_entry_offset, SEEK_SET);
+    for (unsigned int i = 0; i < ctx->data_remap_storage.header->map_entry_count; i++) {
+        fread(&ctx->data_remap_storage.map_entries[i], 0x20, 1, ctx->file);
+        ctx->data_remap_storage.map_entries[i].physical_offset_end = ctx->data_remap_storage.map_entries[i].physical_offset + ctx->data_remap_storage.map_entries[i].size;
+        ctx->data_remap_storage.map_entries[i].virtual_offset_end = ctx->data_remap_storage.map_entries[i].virtual_offset + ctx->data_remap_storage.map_entries[i].size;
+    }
+
+    // lh: InitSegments for DataRemapStorage
+    ctx->data_remap_storage.segments = save_remap_init_segments(ctx->data_remap_storage.header, ctx->data_remap_storage.map_entries, ctx->data_remap_storage.header->map_entry_count);
+
+    // lh: InitDuplexStorage for DuplexStorage using DataRemapStorage
+    ctx->duplex_layers[0].data_a = ctx->duplex_master_bitmap_a;
+    ctx->duplex_layers[0].data_b = ctx->duplex_master_bitmap_b;
+    memcpy(&ctx->duplex_layers[0].info, &ctx->header.duplex_header.layers[0], sizeof(duplex_info_t));
+
+    ctx->duplex_layers[1].data_a = malloc(ctx->header.layout.duplex_l1_size);
+    save_remap_fread(&ctx->data_remap_storage, ctx->duplex_layers[1].data_a, ctx->header.layout.duplex_l1_offset_a, ctx->header.layout.duplex_l1_size);
+    ctx->duplex_layers[1].data_b = malloc(ctx->header.layout.duplex_l1_size);
+    save_remap_fread(&ctx->data_remap_storage, ctx->duplex_layers[1].data_b, ctx->header.layout.duplex_l1_offset_b, ctx->header.layout.duplex_l1_size);
+    memcpy(&ctx->duplex_layers[1].info, &ctx->header.duplex_header.layers[1], sizeof(duplex_info_t));
+
+    ctx->duplex_layers[2].data_a = malloc(ctx->header.layout.duplex_data_size);
+    save_remap_fread(&ctx->data_remap_storage, ctx->duplex_layers[2].data_a, ctx->header.layout.duplex_data_offset_a, ctx->header.layout.duplex_data_size);
+    ctx->duplex_layers[2].data_b = malloc(ctx->header.layout.duplex_data_size);
+    save_remap_fread(&ctx->data_remap_storage, ctx->duplex_layers[2].data_b, ctx->header.layout.duplex_data_offset_b, ctx->header.layout.duplex_data_size);
+    memcpy(&ctx->duplex_layers[2].info, &ctx->header.duplex_header.layers[2], sizeof(duplex_info_t));
+
+    // lh: HierarchicalDuplexStorage ctor for InitDuplexStorage
+    uint8_t *bitmap = ctx->header.layout.duplex_index == 1 ? ctx->duplex_layers[0].data_b : ctx->duplex_layers[0].data_a;
+    save_duplex_storage_init(&ctx->duplex_storage.layers[0], &ctx->duplex_layers[1], bitmap, ctx->header.layout.duplex_master_size);
+    ctx->duplex_storage.layers[0]._length = ctx->header.layout.duplex_l1_size;
+
+    bitmap = malloc(ctx->duplex_storage.layers[0]._length);
+    save_duplex_storage_read(&ctx->duplex_storage.layers[0], bitmap, 0, ctx->duplex_storage.layers[0]._length);
+    save_duplex_storage_init(&ctx->duplex_storage.layers[1], &ctx->duplex_layers[2], bitmap, ctx->duplex_storage.layers[0]._length);
+    ctx->duplex_storage.layers[1]._length = ctx->header.layout.duplex_data_size;
+
+    ctx->duplex_storage.data_layer = ctx->duplex_storage.layers[1];
+
+    // lh: RemapStorage ctor for MetaRemapStorage using DuplexStorage
+    ctx->meta_remap_storage.header = &ctx->header.meta_remap_header;
+    ctx->meta_remap_storage.map_entries = malloc(sizeof(remap_entry_ctx_t) * ctx->meta_remap_storage.header->map_entry_count);
+    fseeko64(ctx->file, ctx->header.layout.meta_map_entry_offset, SEEK_SET);
+    for (unsigned int i = 0; i < ctx->meta_remap_storage.header->map_entry_count; i++) {
+        fread(&ctx->meta_remap_storage.map_entries[i], 0x20, 1, ctx->file);
+        ctx->meta_remap_storage.map_entries[i].physical_offset_end = ctx->meta_remap_storage.map_entries[i].physical_offset + ctx->meta_remap_storage.map_entries[i].size;
+        ctx->meta_remap_storage.map_entries[i].virtual_offset_end = ctx->meta_remap_storage.map_entries[i].virtual_offset + ctx->meta_remap_storage.map_entries[i].size;
+    }
+
+    // lh: InitSegments for MetaRemapStorage
+    ctx->meta_remap_storage.segments = save_remap_init_segments(ctx->meta_remap_storage.header, ctx->meta_remap_storage.map_entries, ctx->meta_remap_storage.header->map_entry_count);
+
+    // lh: JournalMapParams ctor for local journalMapInfo using MetaRemapStorage
+
+    // lh: local journalData from DataRemapStorage
+
+    // lh: JournalStorage ctor for JournalStorage from journalData, journalMapInfo
+
+    // lh: InitJournalIvfcStorage for CoreDataIvfcStorage
+
+    // lh: local fatStorage from MetaRemapStorage
+
+    // lh: InitFatIvfcStorage for FatIvfcStorage
+
+    // lh: SaveDataFileSystemCore ctor for SaveDataFileSystemCore from CoreDataIvfcStorage, fatStorage
 
     if (ctx->tool_ctx->action & ACTION_INFO) {
         save_print(ctx);
@@ -33,24 +242,74 @@ void save_process(save_ctx_t *ctx) {
     }
 }
 
-void save_save(save_ctx_t *ctx) {
+void save_process_header(save_ctx_t *ctx) {
+    if (ctx->header.layout.magic != MAGIC_DISF || ctx->header.duplex_header.magic != MAGIC_DPFS ||
+        ctx->header.data_ivfc_header.magic != MAGIC_IVFC || ctx->header.journal_header.magic != MAGIC_JNGL ||
+        ctx->header.save_header.magic != MAGIC_SAVE || ctx->header.main_remap_header.magic != MAGIC_RMAP ||
+        ctx->header.meta_remap_header.magic != MAGIC_RMAP) {
+        fprintf(stderr, "Error: Save header is corrupt!\n");
+        exit(EXIT_FAILURE);
+    }
 
+    ctx->duplex_master_bitmap_a = (uint8_t *)&ctx->header + ctx->header.layout.duplex_master_offset_a;
+    ctx->duplex_master_bitmap_b = (uint8_t *)&ctx->header + ctx->header.layout.duplex_master_offset_b;
+    ctx->data_ivfc_master = (uint8_t *)&ctx->header + ctx->header.layout.ivfc_master_hash_offset_a;
+    ctx->fat_ivfc_master = (uint8_t *)&ctx->header + ctx->header.layout.fat_ivfc_master_hash_a;
+
+    ctx->header.data_ivfc_header.num_levels = 5;
+
+    if (ctx->header.layout.version >= 0x50000) {
+        ctx->header.fat_ivfc_header.num_levels = 4;
+    }
+
+    ctx->header_hash_validity = check_memory_hash_table(ctx->file, ctx->header.layout.hash, 0x300, 0x3D00, 0x3D00, 0);
+}
+
+void save_free_contexts(save_ctx_t *ctx) {
+    for (unsigned int i = 0; i < ctx->data_remap_storage.header->map_segment_count; i++) {
+        for (unsigned int j = 0; j < ctx->data_remap_storage.segments[i].entry_count; j++) {
+            free(&ctx->data_remap_storage.segments[i].entries[j]);
+        }
+    }
+    free(ctx->data_remap_storage.segments);
+    for (unsigned int i = 0; i < ctx->meta_remap_storage.header->map_segment_count; i++) {
+        for (unsigned int j = 0; j < ctx->meta_remap_storage.segments[i].entry_count; j++) {
+            free(&ctx->meta_remap_storage.segments[i].entries[j]);
+        }
+    }
+    free(ctx->meta_remap_storage.segments);
+    free(ctx->data_remap_storage.map_entries);
+    free(ctx->meta_remap_storage.map_entries);
+    free(ctx->duplex_storage.layers[0].bitmap.bitmap);
+    free(ctx->duplex_storage.layers[1].bitmap.bitmap);
+    free(ctx->duplex_storage.layers[1].bitmap_storage);
+    for (unsigned int i = 1; i < 3; i++) {
+        free(ctx->duplex_layers[i].data_a);
+        free(ctx->duplex_layers[i].data_b);
+    }
+}
+
+void save_save(save_ctx_t *ctx) {
+    filepath_t *dirpath = NULL;
+    if (ctx->tool_ctx->file_type == FILETYPE_SAVE && ctx->tool_ctx->settings.out_dir_path.enabled) {
+        dirpath = &ctx->tool_ctx->settings.out_dir_path.path;
+    }
 }
 
 void save_print_ivfc_section(save_ctx_t *ctx) {
-    print_magic("    Magic:                          ", ctx->header.ivfc_header.magic);
-    printf("    ID:                             %08"PRIx32"\n", ctx->header.ivfc_header.id);
-    memdump(stdout, "    Salt Seed:                      ", &ctx->header.ivfc_header.salt_source, 0x20);
+    print_magic("    Magic:                          ", ctx->header.data_ivfc_header.magic);
+    printf("    ID:                             %08"PRIx32"\n", ctx->header.data_ivfc_header.id);
+    memdump(stdout, "    Salt Seed:                      ", &ctx->header.data_ivfc_header.salt_source, 0x20);
     for (unsigned int i = 0; i < 4; i++) {
         printf("    Level %"PRId32":\n", i);
-        printf("        Data Offset:                0x%016"PRIx64"\n", ctx->header.ivfc_header.level_headers[i].logical_offset);
-        printf("        Data Size:                  0x%016"PRIx64"\n", ctx->header.ivfc_header.level_headers[i].hash_data_size);
+        printf("        Data Offset:                0x%016"PRIx64"\n", ctx->header.data_ivfc_header.level_headers[i].logical_offset);
+        printf("        Data Size:                  0x%016"PRIx64"\n", ctx->header.data_ivfc_header.level_headers[i].hash_data_size);
         if (i != 0) {
-            printf("        Hash Offset:                0x%016"PRIx64"\n", ctx->header.ivfc_header.level_headers[i-1].logical_offset);
+            printf("        Hash Offset:                0x%016"PRIx64"\n", ctx->header.data_ivfc_header.level_headers[i-1].logical_offset);
         } else {
-            printf("        Hash Offset:                0x%016"PRIx64"\n", 0);
+            printf("        Hash Offset:                0x%016"PRIx64"\n", 0x0UL);
         }
-        printf("        Hash Block Size:            0x%08"PRIx32"\n", 1 << ctx->header.ivfc_header.level_headers[i].block_size);
+        printf("        Hash Block Size:            0x%08"PRIx32"\n", 1 << ctx->header.data_ivfc_header.level_headers[i].block_size);
     }
 }
 
@@ -77,7 +336,7 @@ void save_print(save_ctx_t *ctx) {
     printf("\nSave:\n");
 
     if (ctx->tool_ctx->action & ACTION_VERIFY) {
-        if (ctx->disf_cmac_validity == VALIDITY_VALID) {
+        if (ctx->header_cmac_validity == VALIDITY_VALID) {
             memdump(stdout, "Header CMAC (GOOD):                 ", &ctx->header.cmac, 0x10);
         } else {
             memdump(stdout, "Header CMAC (FAIL):                 ", &ctx->header.cmac, 0x10);
@@ -98,7 +357,7 @@ void save_print(save_ctx_t *ctx) {
     printf("Journal Size:                       %016"PRIx64"\n", ctx->header.extra_data.journal_size);
 
     if (ctx->tool_ctx->action & ACTION_VERIFY) {
-        if (ctx->hash_validity == VALIDITY_VALID) {
+        if (ctx->header_hash_validity == VALIDITY_VALID) {
             memdump(stdout, "Header Hash (GOOD):                 ", &ctx->header.layout.hash, 0x20);
         } else {
             memdump(stdout, "Header Hash (FAIL):                 ", &ctx->header.layout.hash, 0x20);

--- a/save.h
+++ b/save.h
@@ -14,7 +14,6 @@
 #define MAGIC_JNGL 0x4C474E4A
 #define MAGIC_SAVE 0x45564153
 #define MAGIC_RMAP 0x50414D52
-#define MAGIC_IVFC 0x43465649
 
 typedef struct save_ctx_t save_ctx_t;
 
@@ -275,7 +274,9 @@ typedef struct {
 } integrity_verification_info_ctx_t;
 
 
-typedef struct {
+typedef struct integrity_verification_storage_ctx_t integrity_verification_storage_ctx_t;
+
+struct integrity_verification_storage_ctx_t {
     ivfc_level_save_ctx_t *hash_storage;
     ivfc_level_save_ctx_t *base_storage;
     validity_t *block_validities;
@@ -283,7 +284,8 @@ typedef struct {
     uint32_t sector_size;
     uint32_t sector_count;
     uint64_t _length;
-} integrity_verification_storage_ctx_t;
+    integrity_verification_storage_ctx_t *next_level;
+};
 
 typedef struct {
     ivfc_level_save_ctx_t levels[5];
@@ -320,6 +322,11 @@ typedef struct {
     uint32_t next_block;
     uint32_t prev_block;
 } allocation_table_iterator_ctx_t;
+
+typedef struct {
+    char name[SAVE_FS_LIST_MAX_NAME_LENGTH];
+    uint32_t parent;
+} save_entry_key_t;
 
 #pragma pack(push, 1)
 typedef struct {

--- a/save.h
+++ b/save.h
@@ -13,6 +13,8 @@
 #define MAGIC_RMAP 0x50414D52
 #define MAGIC_IVFC 0x43465649
 
+typedef struct save_ctx_t save_ctx_t;
+
 typedef struct {
     uint32_t magic; /* DISF */
     uint32_t version;
@@ -248,7 +250,9 @@ typedef struct {
     journal_map_ctx_t map;
     journal_header_t *header;
     uint32_t block_size;
+    uint64_t journal_data_offset;
     uint64_t _length;
+    FILE *file;
 } journal_storage_ctx_t;
 
 typedef struct {
@@ -258,6 +262,7 @@ typedef struct {
     uint32_t hash_block_size;
     validity_t hash_validity;
     enum base_storage_type type;
+    save_ctx_t *save_ctx;
 } ivfc_level_save_ctx_t;
 
 typedef struct {
@@ -269,6 +274,7 @@ typedef struct {
 
 typedef struct {
     ivfc_level_save_ctx_t *hash_storage;
+    ivfc_level_save_ctx_t *base_storage;
     validity_t *block_validities;
     uint8_t salt[0x20];
     uint32_t sector_size;
@@ -284,7 +290,7 @@ typedef struct {
     integrity_verification_storage_ctx_t integrity_storages[4];
 } hierarchical_integrity_verification_storage_ctx_t;
 
-typedef struct {
+struct save_ctx_t {
     FILE *file;
     hactool_ctx_t *tool_ctx;
     save_header_t header;
@@ -300,7 +306,8 @@ typedef struct {
     journal_map_params_t journal_map_info;
     hierarchical_integrity_verification_storage_ctx_t core_data_ivfc_storage;
     hierarchical_integrity_verification_storage_ctx_t fat_ivfc_storage;
-} save_ctx_t;
+    uint8_t *fat_storage;
+};
 
 void save_process(save_ctx_t *ctx);
 void save_process_header(save_ctx_t *ctx);

--- a/save.h
+++ b/save.h
@@ -445,7 +445,4 @@ void save_print(save_ctx_t *ctx);
 
 void save_free_contexts(save_ctx_t *ctx);
 
-void save_duplex_storage_init(duplex_storage_ctx_t *ctx, duplex_fs_layer_info_t *layer, void *bitmap, uint64_t bitmap_size);
-void save_duplex_storage_read(duplex_storage_ctx_t *ctx, void *buffer, uint64_t offset, size_t count);
-
 #endif

--- a/save.h
+++ b/save.h
@@ -1,0 +1,172 @@
+#ifndef HACTOOL_SAVE_H
+#define HACTOOL_SAVE_H
+#include "types.h"
+#include "settings.h"
+#include "ivfc.h"
+
+#define SAVE_HEADER_SIZE 0x4000
+
+#define MAGIC_DISF 0x46534944
+#define MAGIC_DPFS 0x53465044
+#define MAGIC_JNGL 0x4C474E4A
+#define MAGIC_SAVE 0x45564153
+#define MAGIC_RMAP 0x50414D52
+#define MAGIC_IVFC 0x43465649
+
+typedef struct {
+    uint32_t magic; /* DISF */
+    uint32_t version;
+    uint8_t hash[0x20];
+    uint64_t file_map_entry_offset;
+    uint64_t file_map_entry_size;
+    uint64_t meta_map_entry_offset;
+    uint64_t meta_map_entry_size;
+    uint64_t file_map_data_offset;
+    uint64_t file_map_data_size;
+    uint64_t duplex_l1_offset_a;
+    uint64_t duplex_l1_offset_b;
+    uint64_t duplex_l1_size;
+    uint64_t duplex_data_offset_a;
+    uint64_t duplex_data_offset_b;
+    uint64_t duplex_data_size;
+    uint64_t journal_data_offset;
+    uint64_t journal_data_size_a;
+    uint64_t journal_data_size_b;
+    uint64_t journal_size;
+    uint64_t duplex_master_offset_a;
+    uint64_t duplex_master_offset_b;
+    uint64_t duplex_master_size;
+    uint64_t ivfc_master_hash_offset_a;
+    uint64_t ivfc_master_hash_offset_b;
+    uint64_t ivfc_master_hash_size;
+    uint64_t journal_map_table_offset;
+    uint64_t journal_map_table_size;
+    uint64_t journal_physical_bitmap_offset;
+    uint64_t journal_physical_bitmap_size;
+    uint64_t journal_virtual_bitmap_offset;
+    uint64_t journal_virtual_bitmap_size;
+    uint64_t journal_free_bitmap_offset;
+    uint64_t journal_free_bitmap_size;
+    uint64_t ivfc_l1_offset;
+    uint64_t ivfc_l1_size;
+    uint64_t ivfc_l2_offset;
+    uint64_t ivfc_l2_size;
+    uint64_t ivfc_l3_offset;
+    uint64_t ivfc_l3_size;
+    uint64_t fat_offset;
+    uint64_t fat_size;
+    uint64_t duplex_index;
+    uint64_t fat_ivfc_master_hash_a;
+    uint64_t fat_ivfc_master_hash_b;
+    uint64_t fat_ivfc_l1_offset;
+    uint64_t fat_ivfc_l1_size;
+    uint64_t fat_ivfc_l2_offset;
+    uint64_t fat_ivfc_l2_size;
+    uint8_t _0x190[0x70];
+} fs_layout_t;
+
+#pragma pack(push, 1)
+typedef struct {
+    uint64_t offset;
+    uint64_t length;
+    uint32_t block_size_power;
+} duplex_info_t;
+#pragma pack(pop)
+
+typedef struct {
+    uint32_t magic; /* DPFS */
+    uint32_t version;
+    duplex_info_t layers[3];
+} duplex_header_t;
+
+typedef struct {
+    uint32_t version;
+    uint32_t main_data_block_count;
+    uint32_t journal_block_count;
+    uint32_t _0x0C;
+} journal_map_header_t;
+
+typedef struct {
+    uint32_t magic; /* JNGL */
+    uint32_t version;
+    uint64_t total_size;
+    uint64_t journal_size;
+    uint64_t block_size;
+} journal_header_t;
+
+typedef struct {
+    uint32_t magic; /* SAVE */
+    uint32_t version;
+    uint64_t block_count;
+    uint64_t block_size;
+} save_fs_header_t;
+
+typedef struct {
+    uint64_t block_size;
+    uint64_t fat_offset;
+    uint32_t fat_block_count;
+    uint32_t _0x14;
+    uint64_t data_offset;
+    uint32_t data_block_count;
+    uint32_t _0x24;
+    uint32_t directory_table_block;
+    uint32_t file_table_block;
+} fat_header_t;
+
+typedef struct {
+    uint32_t magic; /* RMAP */
+    uint32_t version;
+    uint32_t map_entry_count;
+    uint32_t map_segment_count;
+    uint32_t segment_bits;
+    uint8_t _0x14[0x2C];
+} remap_header_t;
+
+typedef struct {
+    uint64_t title_id;
+    uint8_t user_id[0x10];
+    uint64_t save_id;
+    uint8_t save_data_type;
+    uint8_t _0x21[0x1F];
+    uint64_t save_owner_id;
+    uint64_t timestamp;
+    uint64_t _0x50;
+    uint64_t data_size;
+    uint64_t journal_size;
+    uint64_t commit_id;
+} extra_data_t;
+
+#pragma pack(push, 1)
+typedef struct {
+    uint8_t cmac[0x10];
+    uint8_t _0x10[0xF0];
+    fs_layout_t layout;
+    duplex_header_t duplex_header;
+    ivfc_save_hdr_t ivfc_header;
+    uint32_t _0x404;
+    journal_header_t journal_header;
+    journal_map_header_t map_header;
+    uint8_t _0x438[0x1D0];
+    save_fs_header_t save_header;
+    fat_header_t fat_header;
+    remap_header_t main_remap_header, meta_remap_header;
+    uint64_t _0x6D0;
+    extra_data_t extra_data;
+    uint8_t _0x748[0x390];
+    ivfc_save_hdr_t fat_ivfc_header;
+} save_header_t;
+#pragma pack(pop)
+
+typedef struct {
+    FILE *file;
+    hactool_ctx_t *tool_ctx;
+    save_header_t header;
+    validity_t disf_cmac_validity;
+    validity_t hash_validity;
+} save_ctx_t;
+
+void save_process(save_ctx_t *ctx);
+void save_save(save_ctx_t *ctx);
+void save_print(save_ctx_t *ctx);
+
+#endif

--- a/save.h
+++ b/save.h
@@ -277,7 +277,7 @@ typedef struct {
 } integrity_verification_storage_ctx_t;
 
 typedef struct {
-    ivfc_level_save_ctx_t *levels[5];
+    ivfc_level_save_ctx_t levels[5];
     ivfc_level_save_ctx_t *data_level;
     validity_t **level_validities;
     uint64_t _length;
@@ -297,6 +297,7 @@ typedef struct {
     duplex_fs_layer_info_t duplex_layers[3];
     hierarchical_duplex_storage_ctx_t duplex_storage;
     journal_storage_ctx_t journal_storage;
+    journal_map_params_t journal_map_info;
     hierarchical_integrity_verification_storage_ctx_t core_data_ivfc_storage;
     hierarchical_integrity_verification_storage_ctx_t fat_ivfc_storage;
 } save_ctx_t;

--- a/settings.h
+++ b/settings.h
@@ -18,6 +18,7 @@ typedef enum {
 typedef struct {
     unsigned char secure_boot_key[0x10];                 /* Secure boot key for use in key derivation. NOTE: CONSOLE UNIQUE. */
     unsigned char tsec_key[0x10];                        /* TSEC key for use in key derivation. NOTE: CONSOLE UNIQUE. */
+    unsigned char device_key[0x10];                      /* Device key used to derive some FS keys. NOTE: CONSOLE UNIQUE. */
     unsigned char keyblob_keys[0x20][0x10];              /* Actual keys used to decrypt keyblobs. NOTE: CONSOLE UNIQUE.*/
     unsigned char keyblob_mac_keys[0x20][0x10];          /* Keys used to validate keyblobs. NOTE: CONSOLE UNIQUE. */ 
     unsigned char encrypted_keyblobs[0x20][0xB0];        /* Actual encrypted keyblobs (EKS). NOTE: CONSOLE UNIQUE. */ 
@@ -37,6 +38,7 @@ typedef struct {
     unsigned char package1_keys[0x20][0x10];             /* Package1 keys. */
     unsigned char package2_keys[0x20][0x10];             /* Package2 keys. */
     unsigned char package2_key_source[0x10];             /* Seed for Package2 key. */
+    unsigned char per_console_key_source[0x10];          /* Seed for Device key. */
     unsigned char aes_kek_generation_source[0x10];       /* Seed for GenerateAesKek, usecase + generation 0. */
     unsigned char aes_key_generation_source[0x10];       /* Seed for GenerateAesKey. */
     unsigned char key_area_key_application_source[0x10]; /* Seed for kaek 0. */
@@ -52,6 +54,7 @@ typedef struct {
     unsigned char header_key[0x20];                      /* NCA header key. */
     unsigned char titlekeks[0x20][0x10];                 /* Title key encryption keys. */
     unsigned char key_area_keys[0x20][3][0x10];          /* Key area encryption keys. */
+    unsigned char save_mac_key[0x10];                    /* Key used to sign savedata. */
     unsigned char sd_card_keys[2][0x20];
     unsigned char nca_hdr_fixed_key_modulus[0x100];      /* NCA header fixed key RSA pubk. */
     unsigned char acid_fixed_key_modulus[0x100];         /* ACID fixed key RSA pubk. */

--- a/settings.h
+++ b/settings.h
@@ -130,7 +130,8 @@ enum hactool_file_type
     FILETYPE_KIP1,
     FILETYPE_NSO0,
     FILETYPE_NAX0,
-    FILETYPE_BOOT0
+    FILETYPE_BOOT0,
+    FILETYPE_SAVE
 };
 
 #define ACTION_INFO (1<<0)
@@ -142,6 +143,7 @@ enum hactool_file_type
 #define ACTION_EXTRACTINI1 (1<<6)
 #define ACTION_ONLYUPDATEDROMFS (1<<7)
 #define ACTION_SAVEINIJSON (1<<8)
+#define ACTION_LISTFILES (1<<9)
 
 struct nca_ctx; /* This will get re-defined by nca.h. */
 


### PR DESCRIPTION
Includes CLI options `--outdir` and `--listfiles`, supports existing switch `-y`

Added `save_mac_key` derivation from newly-recognized key `per_console_key_source`

Tested on system and gamesaves, both < and >= version 5 saves

Todo next: save writes