### PR TITLE
Added library build target and switch config-template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 /bin
 /test
 /test/*
+/libhactool.a

--- a/.gitignore
+++ b/.gitignore
@@ -2,8 +2,9 @@
 /hactool
 /hactool.exe
 /*.o
+/*.d
+/*.a
 /*.dll
 /bin
 /test
 /test/*
-/libhactool.a

--- a/Makefile
+++ b/Makefile
@@ -9,12 +9,16 @@ CFLAGS += -D_BSD_SOURCE -D_POSIX_SOURCE -D_POSIX_C_SOURCE=200112L -D_DEFAULT_SOU
 all:
 	cd mbedtls && $(MAKE) lib
 	$(MAKE) hactool
+	$(MAKE) lib
 
 .c.o:
 	$(CC) $(INCLUDE) -c $(CFLAGS) -o $@ $<
 
 hactool: save.o sha.o aes.o extkeys.o rsa.o npdm.o bktr.o kip.o packages.o pki.o pfs0.o hfs0.o nca0_romfs.o romfs.o utils.o nax0.o nso.o lz4.o nca.o xci.o main.o filepath.o ConvertUTF.o cJSON.o
 	$(CC) -o $@ $^ $(LDFLAGS) -L $(LIBDIR)
+
+lib: save.o sha.o aes.o extkeys.o rsa.o npdm.o bktr.o kip.o packages.o pki.o pfs0.o hfs0.o nca0_romfs.o romfs.o utils.o nax0.o nso.o lz4.o nca.o xci.o filepath.o ConvertUTF.o cJSON.o
+	$(AR) -rc $@hactool.a $^
 
 aes.o: aes.h types.h
 
@@ -65,10 +69,9 @@ ConvertUTF.o: ConvertUTF.h
 cJSON.o: cJSON.h
 
 clean:
-	rm -f *.o hactool hactool.exe
+	rm -f *.o hactool hactool.exe libhactool.a
     
-clean_full:
-	rm -f *.o hactool hactool.exe
+clean_full: clean
 	cd mbedtls && $(MAKE) clean
 
 dist: clean_full

--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,6 @@ include config.mk
 
 .PHONY: clean
 
-INCLUDE = -I ./mbedtls/include
-LIBDIR = ./mbedtls/library
 CFLAGS += -D_BSD_SOURCE -D_POSIX_SOURCE -D_POSIX_C_SOURCE=200112L -D_DEFAULT_SOURCE -D__USE_MINGW_ANSI_STDIO=1 -D_FILE_OFFSET_BITS=64
 
 all:
@@ -18,7 +16,13 @@ hactool: save.o sha.o aes.o extkeys.o rsa.o npdm.o bktr.o kip.o packages.o pki.o
 	$(CC) -o $@ $^ $(LDFLAGS) -L $(LIBDIR)
 
 lib: save.o sha.o aes.o extkeys.o rsa.o npdm.o bktr.o kip.o packages.o pki.o pfs0.o hfs0.o nca0_romfs.o romfs.o utils.o nax0.o nso.o lz4.o nca.o xci.o filepath.o ConvertUTF.o cJSON.o
+	rm -rf dist
 	$(AR) -rc $@hactool.a $^
+	mkdir dist
+	mkdir dist/include
+	mkdir dist/lib
+	cp *.h dist/include
+	cp libhactool.a dist/lib
 
 aes.o: aes.h types.h
 
@@ -69,7 +73,7 @@ ConvertUTF.o: ConvertUTF.h
 cJSON.o: cJSON.h
 
 clean:
-	rm -f *.o hactool hactool.exe libhactool.a
+	rm -f *.o *.d hactool hactool.exe libhactool.a
     
 clean_full: clean
 	cd mbedtls && $(MAKE) clean

--- a/aes.c
+++ b/aes.c
@@ -123,9 +123,11 @@ void aes_decrypt(aes_ctx_t *ctx, void *dst, const void *src, size_t l)
             mbedtls_cipher_update(&ctx->cipher_dec, (const unsigned char * )src + offset, len, (unsigned char *)dst + offset, &out_len);
         }
     }
+
+    size_t out;
     
     /* Flush all data */
-    // mbedtls_cipher_finish(&ctx->cipher_dec, NULL, NULL); workaround for crashing on console
+    mbedtls_cipher_finish(&ctx->cipher_dec, NULL, &out);
 
     if (src_equals_dst)
     {

--- a/aes.c
+++ b/aes.c
@@ -125,7 +125,7 @@ void aes_decrypt(aes_ctx_t *ctx, void *dst, const void *src, size_t l)
     }
     
     /* Flush all data */
-    mbedtls_cipher_finish(&ctx->cipher_dec, NULL, NULL);
+    // mbedtls_cipher_finish(&ctx->cipher_dec, NULL, NULL); workaround for crashing on console
 
     if (src_equals_dst)
     {

--- a/config.mk.switch
+++ b/config.mk.switch
@@ -1,0 +1,12 @@
+include $(DEVKITPRO)/libnx/switch_rules
+
+ARCH = -march=armv8-a+crc+crypto -mtune=cortex-a57 -mtp=soft -fPIE
+CFLAGS = -O0 -Wall -Wextra -pedantic -std=gnu11 -fPIC $(ARCH) $(INCLUDE) -D__SWITCH__
+LDFLAGS = -lmbedtls -lmbedx509 -lmbedcrypto
+LIBDIRS = $(PORTLIBS)
+export DEPSDIR	:=	$(CURDIR)/
+
+export INCLUDE	:=	$(foreach dir,$(LIBDIRS),-I$(dir)/include) \
+			-I$(CURDIR)
+
+export LIBDIR	:=	$(foreach dir,$(LIBDIRS),-L$(dir)/lib)

--- a/config.mk.template
+++ b/config.mk.template
@@ -1,3 +1,5 @@
+INCLUDE = -I ./mbedtls/include
+LIBDIR = ./mbedtls/library
 CC = gcc
 CFLAGS = -O2 -Wall -Wextra -pedantic -std=gnu11 -fPIC
 LDFLAGS = -lmbedtls -lmbedx509 -lmbedcrypto

--- a/utils.c
+++ b/utils.c
@@ -205,6 +205,7 @@ const char *get_key_revision_summary(uint8_t key_rev) {
 }
 
 FILE *open_key_file(const char *prefix) {
+#ifndef __SWITCH__
     filepath_t keypath;
     filepath_init(&keypath);
     /* Use $HOME/.switch/prod.keys if it exists */
@@ -240,6 +241,8 @@ FILE *open_key_file(const char *prefix) {
     if (keyfile == NULL && keypath.valid == VALIDITY_VALID) {
         keyfile = os_fopen(keypath.os_path, OS_MODE_READ);
     }
-    
+#else
+    FILE *keyfile = os_fopen("/switch/prod.keys", OS_MODE_READ);
+#endif
     return keyfile;
 }


### PR DESCRIPTION
The last parameter for mbedtls_cipher_finish was changed because newer mbedtls versions will crash if you pass NULL.