### PR TITLE
Update nca.c

### DIFF
--- a/nca.c
+++ b/nca.c
@@ -198,7 +198,7 @@ size_t nca_section_fread(nca_section_ctx_t *ctx, void *buffer, size_t count) {
                 if (count + ctx->sector_ofs < 0x10) {
                     memcpy(buffer, block_buf + ctx->sector_ofs, count);
                     ctx->sector_ofs += count;
-                    nca_section_fseek(ctx, ctx->cur_seek - ctx->offset);
+                    nca_section_fseek(ctx, ctx->cur_seek - ctx->offset + ctx->sector_ofs);
                     return count;
                 }
                 memcpy(buffer, block_buf + ctx->sector_ofs, 0x10 - ctx->sector_ofs);


### PR DESCRIPTION
When reading a very small amount of bytes, sector_ofs must be added to the next fseek, because the function nca_section_fseek doesn't use sector_ofs, it only affects a new value to it, and the line 200 "ctx->sector_ofs += count" would be useless otherwise (sector_ofs is reset to 0, instead of being incremented).