### PR TITLE
ci: add macos build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        job_name: ['linux', 'windows']
+        job_name: ['linux', 'windows', 'macos']
 
         include:
         - job_name: linux
@@ -15,6 +15,10 @@ jobs:
         - job_name: windows
           os: windows-latest
           shell: msys2 {0}
+
+        - job_name: macos
+          os: macos-latest
+          shell: bash {0}
 
     defaults:
       run:


### PR DESCRIPTION
Nothing too special here, I've tested the resulting binary on macOS 11.1

Things that could be added:
- An annoying issue is that the linux and mac builds don't have [executable permissions after unzipping](https://github.com/actions/upload-artifact#permission-loss). A workaround to this could be to [zip it first, then upload the artifact](https://github.com/Gotos/CuteCapture/blob/master/.github/workflows/build.yml#L18-L30).
- There is also a [readme badge](https://github.com/sciresm/hactool/actions/workflows/build.yml/badge.svg) that github provides (![badge](https://github.com/sciresm/hactool/actions/workflows/build.yml/badge.svg)), it gets its name from the [`name`](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#name) key in the workflow yml (in this case, it doesn't exist and defaults to build.yml)

