### PR TITLE
nca: fix parsing CNMT NCA0s

### DIFF
--- a/nca.c
+++ b/nca.c
@@ -585,11 +585,11 @@ void nca_process(nca_ctx_t *ctx) {
 int nca_decrypt_header(nca_ctx_t *ctx) {
     fseeko64(ctx->file, 0, SEEK_SET);
     
-    int is_small_nca = 0;
+    size_t read_size = fread(&ctx->header, 1, 0xC00, ctx->file);
     
-    if (fread(&ctx->header, 1, 0xC00, ctx->file) != 0xC00) {
-        fprintf(stderr, "Warning: NCA too small! Issues may occur.\n");
-        is_small_nca = 1;
+    if (read_size != 0xC00 && read_size != 0xA00) {
+        fprintf(stderr, "Failed to read NCA header!\n");
+        return 0;
     }
 
     /* Try to support decrypted NCA headers. */
@@ -614,8 +614,8 @@ int nca_decrypt_header(nca_ctx_t *ctx) {
     aes_ctx_t *hdr_aes_ctx = new_aes_ctx(ctx->tool_ctx->settings.keyset.header_key, 32, AES_MODE_XTS);
     aes_xts_decrypt(hdr_aes_ctx, &dec_header, &ctx->header, 0x400, 0, 0x200);
 
-    if(is_small_nca && dec_header.magic != MAGIC_NCA0) {
-        fprintf(stderr, "Small and not NCA0, bailing.\n");
+    if(read_size == 0xA00 && dec_header.magic != MAGIC_NCA0) {
+        fprintf(stderr, "Failed to read NCA header!\n");
         return 0;
     }
     

--- a/nca.c
+++ b/nca.c
@@ -585,8 +585,7 @@ void nca_process(nca_ctx_t *ctx) {
 int nca_decrypt_header(nca_ctx_t *ctx) {
     fseeko64(ctx->file, 0, SEEK_SET);
     if (fread(&ctx->header, 1, 0xC00, ctx->file) != 0xC00) {
-        fprintf(stderr, "Failed to read NCA header!\n");
-        return 0;
+        fprintf(stderr, "Warning: NCA too small! Issues may occur.\n");
     }
 
     /* Try to support decrypted NCA headers. */


### PR DESCRIPTION
NCA0s of CNMTs seem to be 0xA00, which is under the 0xC00 minimal threshold of the other versions of the format. 
This PR fixes this by just allowing it to decrypt, and only bailing after, in case the header turns out to not be NCA0.