### PR TITLE
npdm: Update debug flag printout

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
       run:
         shell: ${{ matrix.shell }}
 
-    name: hactool-${{ matrix.job_name }}
+    name: hactuah-${{ matrix.job_name }}
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -44,5 +44,5 @@ jobs:
 
     - uses: actions/upload-artifact@v4
       with:
-        name: hactool-${{ matrix.job_name }}
-        path: hactool*
+        name: hactuah-${{ matrix.job_name }}
+        path: hactuah*

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,13 +36,13 @@ jobs:
         update: true
         install: mingw-w64-x86_64-gcc mingw-w64-x86_64-make
 
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v4
 
     - run: |
         mv config.mk.template config.mk
         make -j$(nproc)
 
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v4
       with:
         name: hactool-${{ matrix.job_name }}
         path: hactool*

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 /config.mk
-/hactool
-/hactool.exe
+/hactuah
+/hactuah.exe
 /*.o
 /*.dll
 /bin

--- a/KEYS.md
+++ b/KEYS.md
@@ -1,4 +1,4 @@
-hactool currently recognizes the following keys (## represents a hexadecimal number between 00 and 1F):
+hactuah currently recognizes the following keys (## represents a hexadecimal number between 00 and 1F):
 
 ```
 master_key_##                   : The ##th Firmware Master Key. Obtainable with TrustZone code execution.

--- a/Makefile
+++ b/Makefile
@@ -8,12 +8,12 @@ CFLAGS += -D_BSD_SOURCE -D_POSIX_SOURCE -D_POSIX_C_SOURCE=200112L -D_DEFAULT_SOU
 
 all:
 	$(MAKE) -C mbedtls lib
-	$(MAKE) hactool$(EXEEXT)
+	$(MAKE) hactuah$(EXEEXT)
 
 .c.o:
 	$(CC) $(INCLUDE) -c $(CFLAGS) -o $@ $<
 
-hactool$(EXEEXT): save.o sha.o aes.o extkeys.o rsa.o npdm.o bktr.o kip.o packages.o pki.o pfs0.o hfs0.o nca0_romfs.o romfs.o utils.o nax0.o nso.o lz4.o nca.o xci.o main.o filepath.o ConvertUTF.o cJSON.o
+hactuah$(EXEEXT): save.o sha.o aes.o extkeys.o rsa.o npdm.o bktr.o kip.o packages.o pki.o pfs0.o hfs0.o nca0_romfs.o romfs.o utils.o nax0.o nso.o lz4.o nca.o xci.o main.o filepath.o ConvertUTF.o cJSON.o
 	$(CC) -o $@ $^ -L $(LIBDIR) $(LDFLAGS)
 
 aes.o: aes.h types.h
@@ -65,17 +65,17 @@ ConvertUTF.o: ConvertUTF.h
 cJSON.o: cJSON.h
 
 clean:
-	rm -f *.o hactool hactool.exe
+	rm -f *.o hactuah hactuah.exe
 
 clean_full:
-	rm -f *.o hactool hactool.exe
+	rm -f *.o hactuah hactuah.exe
 	$(MAKE) -C mbedtls clean
 
 dist: clean_full
-	$(eval HACTOOLVER = $(shell grep '\bHACTOOL_VERSION\b' version.h \
+	$(eval HACTUAHVER = $(shell grep '\bHACTUAH_VERSION\b' version.h \
 		| cut -d' ' -f3 \
 		| sed -e 's/"//g'))
-	mkdir hactool-$(HACTOOLVER)
-	cp -R *.c *.h config.mk.template Makefile README.md LICENSE mbedtls hactool-$(HACTOOLVER)
-	tar czf hactool-$(HACTOOLVER).tar.gz hactool-$(HACTOOLVER)
-	rm -r hactool-$(HACTOOLVER)
+	mkdir hactuah-$(HACTUAHVER)
+	cp -R *.c *.h config.mk.template Makefile README.md LICENSE mbedtls hactuah-$(HACTUAHVER)
+	tar czf hactuah-$(HACTUAHVER).tar.gz hactuah-$(HACTUAHVER)
+	rm -r hactuah-$(HACTUAHVER)

--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
-# hactool
+# hactuah
 
 ![License](https://img.shields.io/badge/license-ISC-blue.svg)
 
-hactool is a tool to view information about, decrypt, and extract common file formats for the Nintendo Switch, especially Nintendo Content Archives.
+hactuah is a tool to view information about, decrypt, and extract common file formats for the Nintendo Switch, especially Nintendo Content Archives.
 
 It is heavily inspired by [ctrtool](https://github.com/profi200/Project_CTR/tree/master/ctrtool).
 
 ## Usage
 
 ```
-Usage: hactool [options...] <file>
+Usage: hactuah [options...] <file>
 Options:
 -i, --info        Show file info.
                       This is the default action.
@@ -105,7 +105,7 @@ External keys can be provided by the -k/--keyset argument to the a keyset filena
 Keyset files are text files containing one key per line, in the form "key_name = HEXADECIMALKEY".
 Case shouldn't matter, nor should whitespace.
 
-In addition, if -k/--keyset is not set, hactool will check for the presence of a keyset file
+In addition, if -k/--keyset is not set, hactuah will check for the presence of a keyset file
 in $HOME/.switch/prod.keys (or $HOME/.switch/dev.keys if -d/--dev is set). If present, this file
 will automatically be loaded.
 

--- a/aes.h
+++ b/aes.h
@@ -1,5 +1,5 @@
-#ifndef HACTOOL_AES_H
-#define HACTOOL_AES_H
+#ifndef HACTUAH_AES_H
+#define HACTUAH_AES_H
 
 #include "mbedtls/cipher.h"
 #include "mbedtls/cmac.h"

--- a/autom4te.cache/traces.0t
+++ b/autom4te.cache/traces.0t
@@ -1,0 +1,2 @@
+m4trace:/usr/share/autoconf/autoconf/trailer.m4:4: -1- _m4_warn([syntax], [AC_INIT was never used], [])
+m4trace:/usr/share/autoconf/autoconf/trailer.m4:4: -1- _m4_warn([syntax], [AC_OUTPUT was never used], [])

--- a/bktr.h
+++ b/bktr.h
@@ -1,5 +1,5 @@
-#ifndef HACTOOL_BKTR_H
-#define HACTOOL_BKTR_H
+#ifndef HACTUAH_BKTR_H
+#define HACTUAH_BKTR_H
 
 #include "types.h"
 

--- a/extkeys.c
+++ b/extkeys.c
@@ -175,7 +175,7 @@ void parse_hex_key(unsigned char *key, const char *hex, unsigned int len) {
     }
 }
 
-void extkeys_parse_titlekeys(hactool_settings_t *settings, FILE *f) {
+void extkeys_parse_titlekeys(HACTUAH_settings_t *settings, FILE *f) {
     char *key, *value;
     int ret;
 
@@ -210,7 +210,7 @@ void extkeys_parse_titlekeys(hactool_settings_t *settings, FILE *f) {
     }
 }
 
-void extkeys_initialize_settings(hactool_settings_t *settings, FILE *f) {
+void extkeys_initialize_settings(HACTUAH_settings_t *settings, FILE *f) {
     char *key, *value;
     int ret;
     nca_keyset_t *keyset = &settings->keyset;
@@ -463,11 +463,11 @@ void extkeys_initialize_settings(hactool_settings_t *settings, FILE *f) {
 }
 
 
-int settings_has_titlekey(hactool_settings_t *settings, const unsigned char *rights_id) {
+int settings_has_titlekey(HACTUAH_settings_t *settings, const unsigned char *rights_id) {
     return settings_get_titlekey(settings, rights_id) != NULL;
 }
 
-void settings_add_titlekey(hactool_settings_t *settings, const unsigned char *rights_id, const unsigned char *titlekey) {
+void settings_add_titlekey(HACTUAH_settings_t *settings, const unsigned char *rights_id, const unsigned char *titlekey) {
     if (settings_has_titlekey(settings, rights_id)) {
         fprintf(stderr, "Error: Rights ID ");
         for (unsigned int i = 0; i < 0x10; i++) {
@@ -495,7 +495,7 @@ void settings_add_titlekey(hactool_settings_t *settings, const unsigned char *ri
     memcpy(new_key->titlekey, titlekey, 0x10);
 }
 
-titlekey_entry_t *settings_get_titlekey(hactool_settings_t *settings, const unsigned char *rights_id) {
+titlekey_entry_t *settings_get_titlekey(HACTUAH_settings_t *settings, const unsigned char *rights_id) {
     for (unsigned int i = 0; i < settings->known_titlekeys.count; i++) {
         if (memcmp(settings->known_titlekeys.titlekeys[i].rights_id, rights_id, 0x10) == 0) {
             return &settings->known_titlekeys.titlekeys[i];

--- a/extkeys.h
+++ b/extkeys.h
@@ -1,5 +1,5 @@
-#ifndef HACTOOL_EXTKEYS_H
-#define HACTOOL_EXTKEYS_H
+#ifndef HACTUAH_EXTKEYS_H
+#define HACTUAH_EXTKEYS_H
 
 #include <string.h>
 #include "types.h"
@@ -7,12 +7,12 @@
 #include "settings.h"
 
 void parse_hex_key(unsigned char *key, const char *hex, unsigned int len);
-void extkeys_initialize_settings(hactool_settings_t *settings, FILE *f);
+void extkeys_initialize_settings(HACTUAH_settings_t *settings, FILE *f);
 
-void extkeys_parse_titlekeys(hactool_settings_t *settings, FILE *f);
+void extkeys_parse_titlekeys(HACTUAH_settings_t *settings, FILE *f);
 
-int settings_has_titlekey(hactool_settings_t *settings, const unsigned char *rights_id);
-void settings_add_titlekey(hactool_settings_t *settings, const unsigned char *rights_id, const unsigned char *titlekey);
-titlekey_entry_t *settings_get_titlekey(hactool_settings_t *settings, const unsigned char *rights_id);
+int settings_has_titlekey(HACTUAH_settings_t *settings, const unsigned char *rights_id);
+void settings_add_titlekey(HACTUAH_settings_t *settings, const unsigned char *rights_id, const unsigned char *titlekey);
+titlekey_entry_t *settings_get_titlekey(HACTUAH_settings_t *settings, const unsigned char *rights_id);
 
 #endif

--- a/filepath.h
+++ b/filepath.h
@@ -1,5 +1,5 @@
-#ifndef HACTOOL_FILEPATH_H
-#define HACTOOL_FILEPATH_H
+#ifndef HACTUAH_FILEPATH_H
+#define HACTUAH_FILEPATH_H
 
 #include "types.h"
 #include "utils.h"

--- a/hfs0.h
+++ b/hfs0.h
@@ -1,5 +1,5 @@
-#ifndef HACTOOL_hfs0_H
-#define HACTOOL_hfs0_H
+#ifndef HACTUAH_hfs0_H
+#define HACTUAH_hfs0_H
 
 #include "types.h"
 #include "utils.h"
@@ -27,7 +27,7 @@ typedef struct {
     FILE *file;
     uint64_t offset;
     uint64_t size;
-    hactool_ctx_t *tool_ctx;
+    HACTUAH_ctx_t *tool_ctx;
     hfs0_header_t *header;
     const char *name;
     const uint8_t *hash_suffix;

--- a/ivfc.h
+++ b/ivfc.h
@@ -1,5 +1,5 @@
-#ifndef HACTOOL_IVFC_H
-#define HACTOOL_IVFC_H
+#ifndef HACTUAH_IVFC_H
+#define HACTUAH_IVFC_H
 
 #include "types.h"
 #include "utils.h"
@@ -90,7 +90,7 @@ typedef struct {
 typedef struct {
     romfs_superblock_t *superblock;
     FILE *file;
-    hactool_ctx_t *tool_ctx;
+    HACTUAH_ctx_t *tool_ctx;
     validity_t superblock_hash_validity;
     ivfc_level_ctx_t ivfc_levels[IVFC_MAX_LEVEL];
     uint64_t romfs_offset;

--- a/kip.h
+++ b/kip.h
@@ -1,5 +1,5 @@
-#ifndef HACTOOL_KIP_H
-#define HACTOOL_KIP_H
+#ifndef HACTUAH_KIP_H
+#define HACTUAH_KIP_H
 #include "types.h"
 #include "utils.h"
 #include "settings.h"
@@ -39,13 +39,13 @@ typedef struct {
 
 typedef struct {
     FILE *file;
-    hactool_ctx_t *tool_ctx;
+    HACTUAH_ctx_t *tool_ctx;
     kip1_header_t *header;
 } kip1_ctx_t;
 
 typedef struct {
     FILE *file;
-    hactool_ctx_t *tool_ctx;
+    HACTUAH_ctx_t *tool_ctx;
     ini1_header_t *header;
     kip1_ctx_t kips[INI1_MAX_KIPS];
 } ini1_ctx_t;

--- a/main.c
+++ b/main.c
@@ -16,12 +16,12 @@
 #include "nso.h"
 #include "save.h"
 
-static const char *prog_name = "hactool";
+static const char *prog_name = "hactuah";
 
 /* Print usage. Taken largely from ctrtool. */
 static void usage(void) {
     fprintf(stderr,
-        "hactool (c) SciresM.\n"
+        "hactuah (c) SciresM.\n"
         "Built: %s %s\n"
         "\n"
         "Usage: %s [options...] <file>\n"
@@ -114,13 +114,13 @@ static void usage(void) {
 }
 
 int main(int argc, char **argv) {
-    hactool_ctx_t tool_ctx;
-    hactool_ctx_t base_ctx; /* Context for base NCA, if used. */
+    HACTUAH_ctx_t tool_ctx;
+    HACTUAH_ctx_t base_ctx; /* Context for base NCA, if used. */
     nca_ctx_t nca_ctx;
     char input_name[0x200];
     filepath_t keypath;
 
-    prog_name = (argc < 1) ? "hactool" : argv[0];
+    prog_name = (argc < 1) ? "hactuah" : argv[0];
 
     nca_init(&nca_ctx);
     memset(&tool_ctx, 0, sizeof(tool_ctx));

--- a/nax0.h
+++ b/nax0.h
@@ -1,5 +1,5 @@
-#ifndef HACTOOL_NAX0_H
-#define HACTOOL_NAX0_H
+#ifndef HACTUAH_NAX0_H
+#define HACTUAH_NAX0_H
 
 #include <stdint.h>
 #include "types.h"
@@ -20,7 +20,7 @@ typedef struct {
 
 typedef struct {
     filepath_t base_path;
-    hactool_ctx_t *tool_ctx;
+    HACTUAH_ctx_t *tool_ctx;
     aes_ctx_t *aes_ctx;
     FILE **files;
     unsigned int num_files;

--- a/nca.h
+++ b/nca.h
@@ -1,5 +1,5 @@
-#ifndef HACTOOL_NCA_H
-#define HACTOOL_NCA_H
+#ifndef HACTUAH_NCA_H
+#define HACTUAH_NCA_H
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -157,7 +157,7 @@ typedef struct {
     uint64_t sector_size;
     uint64_t sector_mask;
     aes_ctx_t *aes; /* AES context for the section. */
-    hactool_ctx_t *tool_ctx;
+    HACTUAH_ctx_t *tool_ctx;
     union {
         pfs0_ctx_t pfs0_ctx;
         romfs_ctx_t romfs_ctx;
@@ -183,7 +183,7 @@ typedef struct nca_ctx {
     enum nca_version format_version;
     validity_t fixed_sig_validity;
     validity_t npdm_sig_validity;
-    hactool_ctx_t *tool_ctx;
+    HACTUAH_ctx_t *tool_ctx;
     unsigned char decrypted_keys[4][0x10];
     unsigned char title_key[0x10];
     nca_section_ctx_t section_contexts[4];

--- a/nca0_romfs.h
+++ b/nca0_romfs.h
@@ -1,5 +1,5 @@
-#ifndef HACTOOL_NCA0_ROMFS_H
-#define HACTOOL_NCA0_ROMFS_H
+#ifndef HACTUAH_NCA0_ROMFS_H
+#define HACTUAH_NCA0_ROMFS_H
 
 #include "types.h"
 #include "utils.h"
@@ -36,7 +36,7 @@ typedef struct {
 typedef struct {
     nca0_romfs_superblock_t *superblock;
     FILE *file;
-    hactool_ctx_t *tool_ctx;
+    HACTUAH_ctx_t *tool_ctx;
     validity_t superblock_hash_validity;
     validity_t hash_table_validity;
     uint64_t romfs_offset;

--- a/npdm.c
+++ b/npdm.c
@@ -432,7 +432,8 @@ void kac_print(const uint32_t *descriptors, uint32_t num_descriptors) {
             case 16: /* Debug Flags. */
                 kac.has_debug_flags = 1;
                 kac.allow_debug = desc & 1;
-                kac.force_debug = (desc >> 1) & 1;
+                kac.force_debug_prod = (desc >> 1) & 1;
+                kac.force_debug = (desc >> 2) & 1;
                 break;
         }
     }
@@ -509,6 +510,7 @@ void kac_print(const uint32_t *descriptors, uint32_t num_descriptors) {
 
     if (kac.has_debug_flags) {
         printf("        Allow Debug:                %s\n", kac.allow_debug ? "YES" : "NO");
+        printf("        Force Debug Prod:           %s\n", kac.force_debug_prod ? "YES" : "NO");
         printf("        Force Debug:                %s\n", kac.force_debug ? "YES" : "NO");
     }
 }
@@ -930,12 +932,14 @@ cJSON *kac_get_json(const uint32_t *descriptors, uint32_t num_descriptors) {
             case 16: /* Debug Flags. */
                 temp = cJSON_CreateObject();
                 cJSON_AddBoolToObject(temp, "allow_debug", (desc >> 0) & 1);
-                cJSON_AddBoolToObject(temp, "force_debug", (desc >> 1) & 1);
+                cJSON_AddBoolToObject(temp, "force_debug_prod", (desc >> 1) & 1);
+                cJSON_AddBoolToObject(temp, "force_debug", (desc >> 2) & 1);
                 cJSON_AddItemToArray(kac_json, kac_create_obj("debug_flags", temp));
 
                // kac.has_debug_flags = 1;
                // kac.allow_debug = desc & 1;
-               // kac.force_debug = (desc >> 1) & 1;
+               // kac.force_debug_prod = (desc >> 1) & 1;
+               // kac.force_debug = (desc >> 2) & 1;
                 break;
         }
         temp = NULL;

--- a/npdm.c
+++ b/npdm.c
@@ -657,7 +657,7 @@ static void fac_print(fac_t *fac, fah_t *fah) {
     printf("\n");
 }
 
-void npdm_process(npdm_t *npdm, hactool_ctx_t *tool_ctx) {
+void npdm_process(npdm_t *npdm, HACTUAH_ctx_t *tool_ctx) {
     if (tool_ctx->action & ACTION_INFO) {
         npdm_print(npdm, tool_ctx);
     }
@@ -667,7 +667,7 @@ void npdm_process(npdm_t *npdm, hactool_ctx_t *tool_ctx) {
     }
 }
 
-void npdm_print(npdm_t *npdm, hactool_ctx_t *tool_ctx) {
+void npdm_print(npdm_t *npdm, HACTUAH_ctx_t *tool_ctx) {
     printf("NPDM:\n");
     print_magic("    Magic:                          ", npdm->magic);
     printf("    MMU Flags:                      %"PRIx8"\n", npdm->mmu_flags);
@@ -734,7 +734,7 @@ void npdm_print(npdm_t *npdm, hactool_ctx_t *tool_ctx) {
 }
 
 
-void npdm_save(npdm_t *npdm, hactool_ctx_t *tool_ctx) {
+void npdm_save(npdm_t *npdm, HACTUAH_ctx_t *tool_ctx) {
     filepath_t *json_path = &tool_ctx->settings.npdm_json_path;
     if (json_path->valid != VALIDITY_VALID) {
         return;

--- a/npdm.h
+++ b/npdm.h
@@ -1,5 +1,5 @@
-#ifndef HACTOOL_NPDM_H
-#define HACTOOL_NPDM_H
+#ifndef HACTUAH_NPDM_H
+#define HACTUAH_NPDM_H
 
 #include "types.h"
 #include "utils.h"
@@ -134,9 +134,9 @@ static inline npdm_aci0_t *npdm_get_aci0(npdm_t *npdm) {
     return (npdm_aci0_t *)((char *)npdm + npdm->aci0_offset);
 }
 
-void npdm_process(npdm_t *npdm, hactool_ctx_t *tool_ctx);
-void npdm_print(npdm_t *npdm, hactool_ctx_t *tool_ctx);
-void npdm_save(npdm_t *npdm, hactool_ctx_t *tool_ctx);
+void npdm_process(npdm_t *npdm, HACTUAH_ctx_t *tool_ctx);
+void npdm_print(npdm_t *npdm, HACTUAH_ctx_t *tool_ctx);
+void npdm_save(npdm_t *npdm, HACTUAH_ctx_t *tool_ctx);
 
 const char *npdm_get_proc_category(int process_category);
 void kac_print(const uint32_t *descriptors, uint32_t num_descriptors);

--- a/npdm.h
+++ b/npdm.h
@@ -41,6 +41,7 @@ typedef struct {
     uint32_t handle_table_size;
     int has_debug_flags;
     int allow_debug;
+    int force_debug_prod;
     int force_debug;
 } kac_t;
 

--- a/nso.h
+++ b/nso.h
@@ -1,5 +1,5 @@
-#ifndef HACTOOL_NSO_H
-#define HACTOOL_NSO_H
+#ifndef HACTUAH_NSO_H
+#define HACTUAH_NSO_H
 #include "types.h"
 #include "utils.h"
 #include "settings.h"
@@ -30,7 +30,7 @@ typedef struct {
 
 typedef struct {
     FILE *file;
-    hactool_ctx_t *tool_ctx;
+    HACTUAH_ctx_t *tool_ctx;
     nso0_header_t *header;
     nso0_header_t *uncompressed_header;
     validity_t segment_validities[3];

--- a/packages.h
+++ b/packages.h
@@ -1,5 +1,5 @@
-#ifndef HACTOOL_PACKAGES_H
-#define HACTOOL_PACKAGES_H
+#ifndef HACTUAH_PACKAGES_H
+#define HACTUAH_PACKAGES_H
 
 #include "types.h"
 #include "utils.h"
@@ -65,7 +65,7 @@ typedef struct {
 
 typedef struct {
     FILE *file;
-    hactool_ctx_t *tool_ctx;
+    HACTUAH_ctx_t *tool_ctx;
     int is_modern;
     int is_mariko;
     int is_decrypted;
@@ -214,7 +214,7 @@ typedef struct {
 
 typedef struct {
     FILE *file;
-    hactool_ctx_t *tool_ctx;
+    HACTUAH_ctx_t *tool_ctx;
     unsigned int key_rev;
     uint32_t package_size;
     validity_t signature_validity;

--- a/pfs0.h
+++ b/pfs0.h
@@ -1,5 +1,5 @@
-#ifndef HACTOOL_PFS0_H
-#define HACTOOL_PFS0_H
+#ifndef HACTUAH_PFS0_H
+#define HACTUAH_PFS0_H
 
 #include "types.h"
 #include "utils.h"
@@ -35,7 +35,7 @@ typedef struct {
 typedef struct {
     pfs0_superblock_t *superblock;
     FILE *file;
-    hactool_ctx_t *tool_ctx;
+    HACTUAH_ctx_t *tool_ctx;
     validity_t superblock_hash_validity;
     validity_t hash_table_validity;
     int is_exefs;

--- a/pki.h
+++ b/pki.h
@@ -1,5 +1,5 @@
-#ifndef HACTOOL_PKI_H
-#define HACTOOL_PKI_H
+#ifndef HACTUAH_PKI_H
+#define HACTUAH_PKI_H
 #include <string.h>
 #include "types.h"
 #include "settings.h"

--- a/rsa.h
+++ b/rsa.h
@@ -1,5 +1,5 @@
-#ifndef HACTOOL_RSA_H
-#define HACTOOL_RSA_H
+#ifndef HACTUAH_RSA_H
+#define HACTUAH_RSA_H
 
 #include "mbedtls/rsa.h"
 

--- a/save.h
+++ b/save.h
@@ -1,5 +1,5 @@
-#ifndef HACTOOL_SAVE_H
-#define HACTOOL_SAVE_H
+#ifndef HACTUAH_SAVE_H
+#define HACTUAH_SAVE_H
 #include "types.h"
 #include "settings.h"
 #include "ivfc.h"
@@ -383,7 +383,7 @@ typedef struct {
 
 struct save_ctx_t {
     FILE *file;
-    hactool_ctx_t *tool_ctx;
+    HACTUAH_ctx_t *tool_ctx;
     save_header_t header;
     validity_t header_cmac_validity;
     validity_t header_hash_validity;

--- a/settings.h
+++ b/settings.h
@@ -1,5 +1,5 @@
-#ifndef HACTOOL_SETTINGS_H
-#define HACTOOL_SETTINGS_H
+#ifndef HACTUAH_SETTINGS_H
+#define HACTUAH_SETTINGS_H
 #include <stdio.h>
 #include "types.h"
 #include "filepath.h"
@@ -13,7 +13,7 @@ typedef enum {
     BASEFILE_ROMFS,
     BASEFILE_NCA,
     BASEFILE_FAKE
-} hactool_basefile_t;
+} HACTUAH_basefile_t;
 
 typedef struct {
     unsigned char secure_boot_key[0x10];                 /* Secure boot key for use in key derivation. NOTE: CONSOLE UNIQUE. */
@@ -122,9 +122,9 @@ typedef struct {
     filepath_t nax0_path;
     filepath_t nax0_sd_path;
     filepath_t npdm_json_path;
-} hactool_settings_t;
+} HACTUAH_settings_t;
 
-enum hactool_file_type
+enum HACTUAH_file_type
 {
     FILETYPE_NCA,
     FILETYPE_PFS0,
@@ -157,13 +157,13 @@ enum hactool_file_type
 struct nca_ctx; /* This will get re-defined by nca.h. */
 
 typedef struct {
-    enum hactool_file_type file_type;
+    enum HACTUAH_file_type file_type;
     FILE *file;
     FILE *base_file;
-    hactool_basefile_t base_file_type;
+    HACTUAH_basefile_t base_file_type;
     struct nca_ctx *base_nca_ctx;
-    hactool_settings_t settings;
+    HACTUAH_settings_t settings;
     uint32_t action;
-} hactool_ctx_t;
+} HACTUAH_ctx_t;
 
 #endif

--- a/sha.h
+++ b/sha.h
@@ -1,5 +1,5 @@
-#ifndef HACTOOL_SHA_H
-#define HACTOOL_SHA_H
+#ifndef HACTUAH_SHA_H
+#define HACTUAH_SHA_H
 
 #include "mbedtls/md.h"
 

--- a/types.h
+++ b/types.h
@@ -1,5 +1,5 @@
-#ifndef HACTOOL_TYPES_H
-#define HACTOOL_TYPES_H
+#ifndef HACTUAH_TYPES_H
+#define HACTUAH_TYPES_H
 
 #include <errno.h>
 #include <inttypes.h>

--- a/utils.h
+++ b/utils.h
@@ -1,5 +1,5 @@
-#ifndef HACTOOL_UTILS_H
-#define HACTOOL_UTILS_H
+#ifndef HACTUAH_UTILS_H
+#define HACTUAH_UTILS_H
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/version.h
+++ b/version.h
@@ -1,6 +1,6 @@
-#ifndef HACTOOL_VERSION_H
-#define HACTOOL_VERSION_H
+#ifndef HACTUAH_VERSION_H
+#define HACTUAH_VERSION_H
 
-#define HACTOOL_VERSION "1.4.0"
+#define HACTUAH_VERSION "1.4.0"
 
 #endif

--- a/xci.c
+++ b/xci.c
@@ -88,7 +88,7 @@ void xci_process(xci_ctx_t *ctx) {
         }
     }
 
-    hactool_ctx_t blank_ctx;
+    HACTUAH_ctx_t blank_ctx;
     memset(&blank_ctx, 0, sizeof(blank_ctx));
     blank_ctx.action = ctx->tool_ctx->action & ~(ACTION_EXTRACT | ACTION_INFO);
 

--- a/xci.h
+++ b/xci.h
@@ -1,5 +1,5 @@
-#ifndef HACTOOL_XCI_H
-#define HACTOOL_XCI_H
+#ifndef HACTUAH_XCI_H
+#define HACTUAH_XCI_H
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -84,7 +84,7 @@ typedef struct {
     hfs0_ctx_t update_ctx;
     hfs0_ctx_t secure_ctx;
     hfs0_ctx_t logo_ctx;
-    hactool_ctx_t *tool_ctx;
+    HACTUAH_ctx_t *tool_ctx;
     unsigned char iv[0x10];
     int has_decrypted_header;
     unsigned char decrypted_header[0x70];


### PR DESCRIPTION
This probably needs an if condition block for when there's less than 3 debug flags to print only allow_debug and force_debug, but at least this way it's able to properly print the debug flags of something built with latest switch-tools (19.0.0)